### PR TITLE
workflows/publish_edge: run in target context

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -1,7 +1,7 @@
 name: Publish to edge
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - snap-1.10
     types:


### PR DESCRIPTION
Otherwise we won't have access to the right environment.