### PR TITLE
tests: fix tests using access points

### DIFF
--- a/tests/core/wifi-connect-secured-ap/task.yaml
+++ b/tests/core/wifi-connect-secured-ap/task.yaml
@@ -4,11 +4,17 @@ environment:
     WIFI_SSID: Ubuntu
     WIFI_PASSPHRASE: Test1234
 
+restore: |
+    . "$SYSTEMSNAPSTESTLIB"/utilities.sh
+
+    network-manager.nmcli c del "$WIFI_SSID"
+    remove_ap
+
 execute: |
     . "$SYSTEMSNAPSTESTLIB"/utilities.sh
 
     create_ap "$WIFI_SSID" "$WIFI_PASSPHRASE"
 
     # Connect to the AP and ensure the connection was established
-    network-manager.nmcli d wifi connect $WIFI_SSID password $WIFI_PASSPHRASE
+    network-manager.nmcli d wifi connect $WIFI_SSID password $WIFI_PASSPHRASE ifname wlan1
     network-manager.nmcli d | grep 'wlan1.*connected'

--- a/tests/core/wifi-wowlan-enabled-correctly/task.yaml
+++ b/tests/core/wifi-wowlan-enabled-correctly/task.yaml
@@ -1,5 +1,11 @@
 summary: Verify WiFi WoWLAN can be enabled in NetworkManager globally via a snap config option
 
+restore: |
+    . "$SYSTEMSNAPSTESTLIB"/utilities.sh
+
+    network-manager.nmcli c del Ubuntu
+    remove_ap
+
 execute: |
     . "$SYSTEMSNAPSTESTLIB"/utilities.sh
 
@@ -11,8 +17,8 @@ execute: |
     create_ap Ubuntu
 
     # Connect to the AP and ensure the connection was established
-    network-manager.nmcli d wifi | grep Ubuntu
-    network-manager.nmcli d wifi connect Ubuntu
+    network-manager.nmcli d wifi list ifname wlan1 | grep Ubuntu
+    network-manager.nmcli d wifi connect Ubuntu ifname wlan1
     network-manager.nmcli d | grep 'wlan1.*connected'
 
     # Now that we're connected a new connection exists which we can look at


### PR DESCRIPTION
In the past the tests were using wifi-ap, but that snap is now unpublished. Use instead NM itself to create the AP.