### PR TITLE
.github/workflows: fix usage of branches

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -1,20 +1,14 @@
 name: Publish to edge
 
 on:
-  pull_request_target:
+  push:
     branches:
-      - snap-1.10
-      - snap-20
       - snap-22
-    types:
-      - closed
 
 jobs:
   publish_to_edge:
     # self-hosted runner so we can access launchpad
     runs-on: self-hosted
-    # Runs when the PR has been merged
-    if: github.event.pull_request.merged == true
     environment: beta
     steps:
       - name: Publish to edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,6 @@ name: Release snap
 on:
   workflow_dispatch:
     branches:
-      - snap-1.10
-      - snap-20
       - snap-22
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,10 +2,6 @@ name: Spread tests
 
 on:
   pull_request:
-    branches:
-      - snap-1.10
-      - snap-20
-      - snap-22
 
 jobs:
   build:


### PR DESCRIPTION
Make sure release jobs are tried only for snap-22 branch, and don't care really about pull request testing.