### PR TITLE
snap/snapcraft: update branches for dnsmasq and network-manager

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
     plugin: make
     source: https://git.launchpad.net/ubuntu/+source/dnsmasq
     source-type: git
-    source-branch: applied/2.79-1ubuntu0.6
+    source-branch: applied/2.79-1ubuntu0.7
     build-packages:
       - build-essential
     make-parameters:
@@ -88,7 +88,7 @@ parts:
     plugin: autotools
     source: https://git.launchpad.net/ubuntu/+source/network-manager
     source-type: git
-    source-branch: applied/1.10.6-2ubuntu1.4
+    source-branch: applied/1.10.6-2ubuntu1.5
     build-packages:
       - intltool
       - libdbus-glib-1-dev


### PR DESCRIPTION
So we get latests sources on which debs are based.