### PR TITLE
snap/snapcraft: update branch for dnsmasq

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
     plugin: make
     source: https://git.launchpad.net/ubuntu/+source/dnsmasq
     source-type: git
-    source-branch: applied/2.79-1ubuntu0.6
+    source-branch: applied/2.79-1ubuntu0.7
     build-packages:
       - build-essential
     make-parameters:


### PR DESCRIPTION
So we get latests sources on which debs are based.