### PR TITLE
Make sure scripts in /etc find /sbin/resolvconf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,10 @@ plugs:
     bus: system
     name: fi.w1.wpa_supplicant1
 
+layout:
+  /sbin/resolvconf:
+    symlink: $SNAP/sbin/resolvconf
+
 hooks:
   configure:
     plugs:


### PR DESCRIPTION
Create a layout for /sbin/resolvconf, as some scripts from /etc check for its existence to manipulate or not the resolv.conf database. This has caused issues with pppd if network-manager is installed on a UC16 system, as files from /etc come from the system and not from the snap base. Race conditions could lead to bad content in resolv.conf in that case.