### PR TITLE
snap,tests: fix the openvpn and no-netplan-default-config spread test

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -372,6 +372,7 @@ parts:
       - usr/lib/*/libteamdctl*
       - usr/lib/openvpn/*
       - usr/lib/*/openvpn/plugins/*
+      - usr/libexec/*openvpn*
       # unwanted
       ## We don't use dhclient so we don't need this helper
       - -usr/lib/NetworkManager/nm-dhcp-helper

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,10 @@ layout:
     bind: $SNAP_DATA/var/lib/NetworkManager
   /usr/sbin/openvpn:
     symlink: $SNAP/usr/sbin/openvpn
+  /usr/libexec/nm-openvpn-service:
+    symlink: $SNAP/usr/libexec/nm-openvpn-service
+  /usr/libexec/nm-openvpn-service-openvpn-helper:
+    symlink: $SNAP/usr/libexec/nm-openvpn-service-openvpn-helper
   # So nm-openvpn-service-openvpn-helper can find it (env including
   # LD_LIBRARY_PATH is not passed down by openvpn).
   /usr/lib/libnm.so.0:

--- a/tests/core/no-netplan-default-config/task.yaml
+++ b/tests/core/no-netplan-default-config/task.yaml
@@ -34,8 +34,10 @@ execute: |
     networkctl status $eth_if | MATCH '(unmanaged|failed)'
     network-manager.nmcli c show --active | MATCH $eth_if | MATCH -v netplan
 
-    # We should only have a single active configuration
-    test `network-manager.nmcli -m multiline -f UUID c show --active | wc -l` -eq 1
+    # Verify the active connections
+    test `network-manager.nmcli -m multiline -f UUID c show --active | wc -l` -eq 2
+    network-manager.nmcli -m multiline -f DEVICE c show --active | MATCH "lo"
+    network-manager.nmcli -m multiline -f DEVICE c show --active | MATCH "ens4"
 
     # Verify that we can modify the automatically created connection
     connection=$(network-manager.nmcli -m multiline -f UUID c show --active | awk '{print$2;exit}')


### PR DESCRIPTION
For the `no-netplan-default-config` spread test, it turns out we have the default loopback device present, along with the actual eth interface, make sure the test does not fail on this.

For the openvpn one, it turns out the openvpn libexec binaries were not being staged in the new version.