### PR TITLE
netplan: backport patches to ignore temporary connections generated by NM (LP: #2065375)

### DIFF
--- a/snap-patch/networkmanager/0002-nm-netplan-keyfile.patch
+++ b/snap-patch/networkmanager/0002-nm-netplan-keyfile.patch
@@ -274,12 +274,13 @@ index fa95198c0084ac6b907f7ffa7ba826a1cca6a025..1b8affdfe91935049edc9ba4323dc627
                              GError **error)
  {
  	gs_unref_keyfile GKeyFile *kf_file = NULL;
-@@ -364,6 +369,113 @@ _internal_write_connection (NMConnection *connection,
+@@ -364,6 +369,114 @@ _internal_write_connection (NMConnection *connection,
  	    && !nm_streq (path, existing_path))
  		unlink (existing_path);
  
-+	/* NETPLAN: write only non-volatile files to /etc/netplan/... */
-+	if (!is_volatile) {
++	/* NETPLAN: write only non-temporary files to /etc/netplan/... */
++	if (!is_volatile && !is_nm_generated &&
++		strstr(keyfile_dir, "/etc/NetworkManager/system-connections")) {
 +		g_autofree gchar* ssid = g_key_file_get_string(kf_file, "wifi", "ssid", NULL);
 +		g_autofree gchar* escaped_ssid = ssid ?
 +		                                 g_uri_escape_string(ssid, NULL, TRUE) : NULL;


### PR DESCRIPTION
Direct backports from the snap-22 branch:
- https://github.com/canonical/network-manager-snap/commit/c6b44b3
- https://github.com/canonical/network-manager-snap/commit/3fa4be6

I've dropped the `!is_external` check in the backport, as that variable does not yet exist on NM 1.22. But by definition an `external` connection is also `nm_generated`, which we are now checking for here, see:
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/96c9703b50cac9287daf04ca28e932ba6339d53d

This should solve LP: #2065375
Old reference: https://bugs.launchpad.net/netplan/+bug/1998207

Replaces: https://github.com/canonical/network-manager-snap/pull/44