### PR TITLE
snapcraft: adopt network-manager to noble-updates

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -164,7 +164,7 @@ parts:
     plugin: autotools
     source: https://git.launchpad.net/ubuntu/+source/network-manager
     source-type: git
-    source-branch: applied/ubuntu/noble
+    source-branch: applied/ubuntu/noble-updates
     build-packages:
       - gettext
       - libglib2.0-dev


### PR DESCRIPTION
The NetworkManager package in Noble received an SRU, so we now need to build from the noble-updates branch.

Replaces: https://github.com/canonical/network-manager-snap/pull/46