### PR TITLE
CI: use self-hosted x64 runners

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish_to_edge:
     # self-hosted runner so we can access launchpad
-    runs-on: self-hosted
+    runs-on: [self-hosted, x64, linux]
     environment: beta
     steps:
       - name: Publish to edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_release:
-    runs-on: self-hosted
+    runs-on: [self-hosted, x64, linux]
     environment: beta
     steps:
       - name: Build release

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     # self-hosted runner so we can access gce from external repos
-    runs-on: self-hosted
+    runs-on: [self-hosted, x64, linux]
     steps:
       - name: Build and test
         env:


### PR DESCRIPTION
To avoid failures like this:
+ spread google: ./cicd/workflows/snap-release.sh: line 373: /home/ubuntu/bin/spread: cannot execute binary file: Exec format error