### PR TITLE
Re-enable riscv64, as we have snapd 2.64 now

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -16,6 +16,3 @@ jobs:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         uses: snapcore/system-snaps-cicd-tools/action-publish-edge@main
-        with:
-          # TODO: remove this filter when snapd 2.64 is released
-          architectures: arm64,amd64,armhf

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,3 @@ jobs:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         uses: snapcore/system-snaps-cicd-tools/action-release@main
-        with:
-          # TODO: remove this filter when snapd 2.64 is released
-          architectures: arm64,amd64,armhf

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,3 @@ jobs:
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
         uses: snapcore/system-snaps-cicd-tools/action-test@main
-        with:
-          # TODO: remove this filter when snapd 2.64 is released
-          architectures: arm64,amd64,armhf


### PR DESCRIPTION
CI: drop architecture limitation
    
Undo changes from https://github.com/canonical/network-manager-snap/pull/35 as we now have snapd v2.67.1+24.04 in noble-updates.
    
This should enable riscv64 builds.