### PR TITLE
snapcraft: Fix FTBFS by consuming Dnsmasq from the esm-infra-security private PPA

### DIFF
--- a/snap-patch/dnsmasq.patch
+++ b/snap-patch/dnsmasq.patch
@@ -80,7 +80,7 @@ index ce44809..17c451b 100644
    
        if (ent_pw && ent_pw->pw_uid != 0)
  	{     
-@@ -654,11 +654,11 @@ int main (int argc, char **argv)
+@@ -654,10 +654,10 @@ int main (int argc, char **argv)
  	    }
  	  
  	  /* finally drop root */
@@ -96,7 +96,6 @@ index ce44809..17c451b 100644
 +	  /*   }      */
  
  #ifdef HAVE_LINUX_NETWORK
- 	  if (is_dad_listeners() || option_bool(OPT_CLEVERBIND))
 -- 
 2.17.1
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,14 @@ apps:
             hardware-observe, network-setup-control, login-session-observe,
             network-observe]
 
+package-repositories:
+  - type: apt
+    formats: [deb, deb-src]
+    components: [main]
+    suites: [bionic]
+    key-id: DBB1FC89762BF6B96707C4059BC0A1A1622CF918
+    url: http://private-ppa.buildd/ubuntu-esm/esm-infra-security/ubuntu
+
 parts:
   networkmanager-common:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,14 +76,20 @@ parts:
 
   dnsmasq:
     plugin: make
-    source: https://git.launchpad.net/ubuntu/+source/dnsmasq
-    source-type: git
-    source-branch: applied/2.79-1ubuntu0.7
+    source: .  # IGNORE: will be replace by ESM dnsmasq source package, but local-dir is faster than git checkout
+    source-branch: applied/2.90-0ubuntu0.18.04.1+esm1  # Spoofing the ESM version string for build-tools/cmp-stage-build.py
     build-packages:
       - build-essential
     make-parameters:
       - PREFIX=/
     override-build: |
+      cd ..
+      rm -rf build/
+      # pull dnsmasq from ESM private PPA
+      apt-get source dnsmasq
+      mv dnsmasq-2.90/ build/
+      rm dnsmasq*
+      cd build/
       git apply "$SNAPCRAFT_PROJECT_DIR"/snap-patch/dnsmasq.patch
       snapcraftctl build
     filesets:


### PR DESCRIPTION
Consume dnsmasq from esm-infra-security private PPA source package.

See https://wiki.ubuntu.com/SecurityTeam/BuildEnvironment#Setting_up_a_chroot_for_Extended_Security_Maintenance for how to gain access to this private PPA.