### PR TITLE
Fix FTBFS by consuming Dnsmasq from the ESM repository

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,14 +54,6 @@ apps:
             hardware-observe, network-setup-control, login-session-observe,
             network-observe]
 
-package-repositories:
-  - type: apt
-    formats: [deb, deb-src]
-    components: [main]
-    suites: [bionic]
-    key-id: DBB1FC89762BF6B96707C4059BC0A1A1622CF918
-    url: http://private-ppa.buildd/ubuntu-esm/esm-infra-security/ubuntu
-
 parts:
   networkmanager-common:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,6 +77,12 @@ parts:
     override-build: |
       cd ..
       rm -rf build/
+      # Enable 'deb-src' for the ESM repositories
+      sudo mkdir -p /etc/apt/sources.list.d
+      sudo touch /etc/apt/sources.list.d/empty.list  # make SED happy if no PPAs are installed
+      sudo sed -i '/@private-ppa.buildd\/ubuntu-esm/{p;s/deb /deb-src /g;}' /etc/apt/*.list
+      sudo sed -i '/@private-ppa.buildd\/ubuntu-esm/{p;s/deb /deb-src /g;}' /etc/apt/sources.list.d/*.list
+      sudo apt update
       # pull dnsmasq from ESM private PPA
       apt-get source dnsmasq
       mv dnsmasq-2.90/ build/


### PR DESCRIPTION
Follow-up to https://github.com/canonical/network-manager-snap/pull/51 using some `sed` magic for enabeling the `deb-src` ESM repositories.