### PR TITLE
Fix errors when trying to fetch Changelogs for ESM packages.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,6 +60,8 @@ package-repositories:
     components: [main]
     suites: [bionic]
     key-id: DBB1FC89762BF6B96707C4059BC0A1A1622CF918
+    # Use https://USER:KEY@private-ppa.launchpadcontent.net/ubuntu-esm/... for
+    # local builds, see https://launchpad.net/people/+me/+archivesubscriptions
     url: http://private-ppa.buildd/ubuntu-esm/esm-infra-security/ubuntu
 
 parts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -271,6 +271,35 @@ parts:
         - usr/share/doc/network-manager/copyright
         - usr/share/doc/ppp/copyright
         - usr/share/doc/resolvconf/copyright
+        # Changelogs
+        - usr/share/doc/dnsmasq/changelog.*
+        - usr/share/doc/network-manager/changelog.*
+        - usr/share/doc/iputils-arping/changelog.*
+        - usr/share/doc/libasn1-8-heimdal/changelog.*
+        - usr/share/doc/libcurl3-gnutls/changelog.*
+        - usr/share/doc/libdbus-glib-1-2/changelog.*
+        - usr/share/doc/libgssapi3-heimdal/changelog.*
+        - usr/share/doc/libhcrypto4-heimdal/changelog.*
+        - usr/share/doc/libheimbase1-heimdal/changelog.*
+        - usr/share/doc/libheimntlm0-heimdal/changelog.*
+        - usr/share/doc/libhx509-5-heimdal/changelog.*
+        - usr/share/doc/libjansson4/changelog.*
+        - usr/share/doc/libkrb5-26-heimdal/changelog.*
+        - usr/share/doc/libldap-2.4-2/changelog.*
+        - usr/share/doc/libmm-glib0/changelog.*
+        - usr/share/doc/libndp0/changelog.*
+        - usr/share/doc/libnewt0.52/changelog.*
+        - usr/share/doc/libnghttp2-14/changelog.*
+        - usr/share/doc/libpcap0.8/changelog.*
+        - usr/share/doc/libpsl5/changelog.*
+        - usr/share/doc/libroken18-heimdal/changelog.*
+        - usr/share/doc/librtmp1/changelog.*
+        - usr/share/doc/libsasl2-2/changelog.*
+        - usr/share/doc/libslang2/changelog.*
+        - usr/share/doc/libteamdctl0/changelog.*
+        - usr/share/doc/libwind0-heimdal/changelog.*
+        - usr/share/doc/ppp/changelog.*
+        - usr/share/doc/resolvconf/changelog.*
       libs:
         - lib/resolvconf/list-records
         - lib/*/libnewt*


### PR DESCRIPTION
Follow-up to #51

Fixes: https://github.com/canonical/system-snaps-cicd-tools/issues/19


For comparison, see: https://github.com/canonical/network-manager-snap/commit/988f83d3dad62c6885c13fa144b40cb2862451dc