### PR TITLE
n-dhcp4: Do not set ciaddr in DISCOVER state.

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     # self-hosted runner so we can access launchpad
-    runs-on: self-hosted
+    runs-on: [self-hosted, x64, linux, spread-enabled]
     environment: beta
     steps:
       - name: Publish to edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build_release:
-    runs-on: self-hosted
+    runs-on: [self-hosted, x64, linux, spread-enabled]
     environment: beta
     steps:
       - name: Build release

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     # self-hosted runner so we can access gce from external repos
-    runs-on: self-hosted
+    runs-on: [self-hosted, x64, linux, spread-enabled]
     steps:
       - name: Build and test
         env:

--- a/snap-patch/networkmanager/0006-n-dhcp4-Do-not-set-ciaddr-in-DISCOVER-state.patch
+++ b/snap-patch/networkmanager/0006-n-dhcp4-Do-not-set-ciaddr-in-DISCOVER-state.patch
@@ -1,25 +1,28 @@
-From: =?utf-8?q?Lukas_M=C3=A4rdian?= <slyon@ubuntu.com>
-Date: Mon, 28 Jul 2025 15:50:19 +0200
-Subject: n-dhcp4: Do not set ciaddr in DISCOVER state.
+From b0535e7cef8232de3a01cd7150384a20d4ae446a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lukas=20M=C3=A4rdian?= <slyon@ubuntu.com>
+Date: Mon, 28 Jul 2025 20:15:53 +0200
+Subject: [PATCH] n-dhcp4: Do not set ciaddr in DISCOVER state.
 
+This is invalid according to RFC 2131 table 1 ("Description of fields in a DHCP
+message") and has previously been discussed in #45.
+
+Fixes #45
+
+Forwarded: https://github.com/nettools/n-dhcp4/pull/48
 ---
- shared/n-dhcp4/src/n-dhcp4-c-connection.c | 6 ++++++
- 1 file changed, 6 insertions(+)
+ shared/n-dhcp4/src/n-dhcp4-c-probe.c | 2 ++
+ 1 file changed, 2 insertions(+)
 
-diff --git a/shared/n-dhcp4/src/n-dhcp4-c-connection.c b/shared/n-dhcp4/src/n-dhcp4-c-connection.c
-index 2f660e3..600a50b 100644
---- a/shared/n-dhcp4/src/n-dhcp4-c-connection.c
-+++ b/shared/n-dhcp4/src/n-dhcp4-c-connection.c
-@@ -528,6 +528,12 @@ static int n_dhcp4_c_connection_new_message(NDhcp4CConnection *connection,
-         message->userdata.type = type;
-         message->userdata.message_type = message_type;
+diff --git a/shared/n-dhcp4/src/n-dhcp4-c-probe.c b/shared/n-dhcp4/src/n-dhcp4-c-probe.c
+index 8a3788d..a36dba6 100644
+--- a/shared/n-dhcp4/src/n-dhcp4-c-probe.c
++++ b/shared/n-dhcp4/src/n-dhcp4-c-probe.c
+@@ -703,6 +703,8 @@ static int n_dhcp4_client_probe_transition_deferred(NDhcp4ClientProbe *probe, ui
  
-+        /* Do not set a Client IP in DISCOVERY state */
-+        if (type == N_DHCP4_C_MESSAGE_DISCOVER) {
-+                message->message->header.ciaddr = INADDR_ANY;
-+                connection->client_ip = INADDR_ANY;  // reset client IP
-+        }
-+
-         /*
-          * Note that some implementations expect the MESSAGE_TYPE option to be
-          * the first option, and possibly even hard-code access to it. Hence,
+         switch (probe->state) {
+         case N_DHCP4_CLIENT_PROBE_STATE_INIT:
++                /* reset client IP (CIADDR) */
++                probe->connection.client_ip = INADDR_ANY;
+                 r = n_dhcp4_c_connection_listen(&probe->connection);
+                 if (r)
+                         return r;

--- a/snap-patch/networkmanager/0006-n-dhcp4-Do-not-set-ciaddr-in-DISCOVER-state.patch
+++ b/snap-patch/networkmanager/0006-n-dhcp4-Do-not-set-ciaddr-in-DISCOVER-state.patch
@@ -1,0 +1,25 @@
+From: =?utf-8?q?Lukas_M=C3=A4rdian?= <slyon@ubuntu.com>
+Date: Mon, 28 Jul 2025 15:50:19 +0200
+Subject: n-dhcp4: Do not set ciaddr in DISCOVER state.
+
+---
+ shared/n-dhcp4/src/n-dhcp4-c-connection.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/shared/n-dhcp4/src/n-dhcp4-c-connection.c b/shared/n-dhcp4/src/n-dhcp4-c-connection.c
+index 2f660e3..600a50b 100644
+--- a/shared/n-dhcp4/src/n-dhcp4-c-connection.c
++++ b/shared/n-dhcp4/src/n-dhcp4-c-connection.c
+@@ -528,6 +528,12 @@ static int n_dhcp4_c_connection_new_message(NDhcp4CConnection *connection,
+         message->userdata.type = type;
+         message->userdata.message_type = message_type;
+ 
++        /* Do not set a Client IP in DISCOVERY state */
++        if (type == N_DHCP4_C_MESSAGE_DISCOVER) {
++                message->message->header.ciaddr = INADDR_ANY;
++                connection->client_ip = INADDR_ANY;  // reset client IP
++        }
++
+         /*
+          * Note that some implementations expect the MESSAGE_TYPE option to be
+          * the first option, and possibly even hard-code access to it. Hence,

--- a/snap-patch/networkmanager/0007-n-dhcp4-introduce-n_dhcp4_c_connection_clear_client_ip.patch
+++ b/snap-patch/networkmanager/0007-n-dhcp4-introduce-n_dhcp4_c_connection_clear_client_ip.patch
@@ -1,0 +1,54 @@
+From d9f4e8cc8d09efbc6d43a684d6a7ad0fd9b70209 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lukas=20M=C3=A4rdian?= <slyon@ubuntu.com>
+Date: Thu, 11 Sep 2025 16:27:26 +0200
+Subject: [PATCH] n-dhcp4: introduce n_dhcp4_c_connection_clear_client_ip()
+ helper
+
+Forwarded: https://github.com/nettools/n-dhcp4/pull/48
+---
+ shared/n-dhcp4/src/n-dhcp4-c-connection.c | 4 ++++
+ shared/n-dhcp4/src/n-dhcp4-c-probe.c      | 2 +-
+ shared/n-dhcp4/src/n-dhcp4-private.h      | 2 ++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/shared/n-dhcp4/src/n-dhcp4-c-connection.c b/shared/n-dhcp4/src/n-dhcp4-c-connection.c
+index 7681fbc..cf5b2ac 100644
+--- a/shared/n-dhcp4/src/n-dhcp4-c-connection.c
++++ b/shared/n-dhcp4/src/n-dhcp4-c-connection.c
+@@ -379,6 +379,10 @@ void n_dhcp4_c_connection_get_timeout(NDhcp4CConnection *connection,
+         *timeoutp = timeout;
+ }
+ 
++void n_dhcp4_c_connection_clear_client_ip(NDhcp4CConnection *connection) {
++        connection->client_ip = INADDR_ANY;
++}
++
+ static int n_dhcp4_c_connection_packet_broadcast(NDhcp4CConnection *connection,
+                                                  NDhcp4Outgoing *message) {
+         int r;
+diff --git a/shared/n-dhcp4/src/n-dhcp4-c-probe.c b/shared/n-dhcp4/src/n-dhcp4-c-probe.c
+index a36dba6..9b8526e 100644
+--- a/shared/n-dhcp4/src/n-dhcp4-c-probe.c
++++ b/shared/n-dhcp4/src/n-dhcp4-c-probe.c
+@@ -704,7 +704,7 @@ static int n_dhcp4_client_probe_transition_deferred(NDhcp4ClientProbe *probe, ui
+         switch (probe->state) {
+         case N_DHCP4_CLIENT_PROBE_STATE_INIT:
+                 /* reset client IP (CIADDR) */
+-                probe->connection.client_ip = INADDR_ANY;
++                n_dhcp4_c_connection_clear_client_ip(&probe->connection);
+                 r = n_dhcp4_c_connection_listen(&probe->connection);
+                 if (r)
+                         return r;
+diff --git a/shared/n-dhcp4/src/n-dhcp4-private.h b/shared/n-dhcp4/src/n-dhcp4-private.h
+index 4040400..529a3ea 100644
+--- a/shared/n-dhcp4/src/n-dhcp4-private.h
++++ b/shared/n-dhcp4/src/n-dhcp4-private.h
+@@ -617,6 +617,8 @@ void n_dhcp4_c_connection_close(NDhcp4CConnection *connection);
+ void n_dhcp4_c_connection_get_timeout(NDhcp4CConnection *connection,
+                                       uint64_t *timeoutp);
+ 
++void n_dhcp4_c_connection_clear_client_ip(NDhcp4CConnection *connection);
++
+ int n_dhcp4_c_connection_discover_new(NDhcp4CConnection *connection,
+                                       NDhcp4Outgoing **request);
+ int n_dhcp4_c_connection_select_new(NDhcp4CConnection *connection,


### PR DESCRIPTION
 Do not set ciaddr in DISCOVER state. As this is invalid according to RFC 2131 table 1 ("Description of fields in a DHCP message").
    
Forwarded: https://github.com/nettools/n-dhcp4/pull/48

Bug-Ubuntu: https://bugs.launchpad.net/shiner/+bug/2116214