### PR TITLE
CI: Debug snapcraft version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,9 @@ jobs:
     # self-hosted runner so we can access gce from external repos
     runs-on: [self-hosted, x64, linux, spread-enabled]
     steps:
+      - name: Snapcraft version
+        run: |
+          snap info snapcraft
       - name: Build and test
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}


### PR DESCRIPTION
Debugging, trying to resolve issues like this:


```
+ snapcraft whoami
/snap/bin/snapcraft
Store operation failed:
- macaroon-authorization-required: The request is missing an Authorization header field containing a valid macaroon

Exported credentials are no longer valid for the Snap Store.
Recommended resolution: Run export-login and update SNAPCRAFT_STORE_CREDENTIALS.
```