### PR TITLE
core20: Fix fetching of changelogs for ESM packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -322,6 +322,7 @@ parts:
         - etc/NetworkManager/*
         - etc/resolvconf/update.d/libc
       docs:
+        - usr/share/doc/dnsmasq/copyright
         - usr/share/doc/iputils-arping/copyright
         - usr/share/doc/libasn1-8-heimdal/copyright
         - usr/share/doc/libbrotli1/copyright
@@ -348,8 +349,40 @@ parts:
         - usr/share/doc/libssh-4/copyright
         - usr/share/doc/libteamdctl0/copyright
         - usr/share/doc/libwind0-heimdal/copyright
+        - usr/share/doc/network-manager/copyright
         - usr/share/doc/ppp/copyright
         - usr/share/doc/resolvconf/copyright
+        # Changelogs
+        - usr/share/doc/dnsmasq/changelog.*
+        - usr/share/doc/iputils-arping/changelog.*
+        - usr/share/doc/libasn1-8-heimdal/changelog.*
+        - usr/share/doc/libbrotli1/changelog.*
+        - usr/share/doc/libcurl3-gnutls/changelog.*
+        - usr/share/doc/libdbus-glib-1-2/changelog.*
+        - usr/share/doc/libgssapi3-heimdal/changelog.*
+        - usr/share/doc/libhcrypto4-heimdal/changelog.*
+        - usr/share/doc/libheimbase1-heimdal/changelog.*
+        - usr/share/doc/libheimntlm0-heimdal/changelog.*
+        - usr/share/doc/libhx509-5-heimdal/changelog.*
+        - usr/share/doc/libjansson4/changelog.*
+        - usr/share/doc/libkrb5-26-heimdal/changelog.*
+        - usr/share/doc/libldap-2.4-2/changelog.*
+        - usr/share/doc/libmm-glib0/changelog.*
+        - usr/share/doc/libndp0/changelog.*
+        - usr/share/doc/libnewt0.52/changelog.*
+        - usr/share/doc/libnghttp2-14/changelog.*
+        - usr/share/doc/libpcap0.8/changelog.*
+        - usr/share/doc/libpsl5/changelog.*
+        - usr/share/doc/libroken18-heimdal/changelog.*
+        - usr/share/doc/librtmp1/changelog.*
+        - usr/share/doc/libsasl2-2/changelog.*
+        - usr/share/doc/libslang2/changelog.*
+        - usr/share/doc/libssh-4/changelog.*
+        - usr/share/doc/libteamdctl0/changelog.*
+        - usr/share/doc/libwind0-heimdal/changelog.*
+        - usr/share/doc/network-manager/changelog.*
+        - usr/share/doc/ppp/changelog.*
+        - usr/share/doc/resolvconf/changelog.*
       libs:
         - lib/resolvconf/list-records
         - lib/*/libslang*


### PR DESCRIPTION
snapcraft: deploy local changelogs for ESM package compatibility

ESM changelogs will not be available at e.g.:
https://changelogs.ubuntu.com/changelogs/binary/libs/libssh-4/0.9.3-2ubuntu2.5+esm1/changelog

Making the build_release workflow like:
```
FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/actions-runner/_work/_temp/new_man/usr/share/doc//libssh-4/changelog.Debian.gz'
Exception: No changelog found in https://changelogs.ubuntu.com/changelogs/binary/libs/libssh-4/0.9.3-2ubuntu2.5+esm1/changelog - status:40
```

Similar to: https://github.com/canonical/network-manager-snap/pull/53