### PR TITLE
CI: Use store environment

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -9,7 +9,7 @@ jobs:
   publish_to_edge:
     # self-hosted runner so we can access launchpad
     runs-on: [self-hosted, x64, linux, spread-enabled]
-    environment: beta
+    environment: store
     steps:
       - name: Publish to edge
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_release:
     runs-on: [self-hosted, x64, linux, spread-enabled]
-    environment: beta
+    environment: store
     steps:
       - name: Build release
         env:


### PR DESCRIPTION
Checking if using `environment: store` (over "beta") fixes issues with deploying snaps.

The new `se_utils.download_snap_build()` method (https://github.com/canonical/system-snaps-cicd-tools/pull/30) is more strict/sensitive to the environment setting than the old download function was.