### PR TITLE
Prepare for Ubuntu Noble based snap-26 track

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - snap-26
+  schedule:
+    # Run on the first Sunday of the month at 02:00 UTC
+    - cron: '0 2 1-7 * SUN'
 
 jobs:
   publish_to_edge:

--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -3,7 +3,7 @@ name: Publish to edge
 on:
   push:
     branches:
-      - snap-24
+      - snap-26
 
 jobs:
   publish_to_edge:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release snap
 on:
   workflow_dispatch:
     branches:
-      - snap-24
+      - snap-26
 
 jobs:
   build_release:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Spread tests
 on:
   pull_request:
     branches:
-      - snap-24
+      - snap-26
 
 jobs:
   build:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: network-manager
-version: 1.46.0-8-dev
+version: 1.54.2-1-dev
 summary: Network Manager
 description: |
   NetworkManager is a system network service that manages your network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,8 +8,8 @@ description: |
   PPPoE devices, provides VPN integration with a variety of different
   VPN services.
   Please find the source code for this track at:
-    https://code.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/+git/network-manager/+ref/snap-24
-base: core24
+    https://github.com/canonical/network-manager-snap/tree/snap-26
+base: core26
 confinement: strict
 grade: stable
 
@@ -143,7 +143,7 @@ parts:
     plugin: make
     source: https://git.launchpad.net/ubuntu/+source/dnsmasq
     source-type: git
-    source-branch: applied/ubuntu/noble-updates
+    source-branch: applied/ubuntu/resolute
     build-packages:
       - build-essential
     make-parameters:
@@ -164,7 +164,7 @@ parts:
     plugin: autotools
     source: https://git.launchpad.net/ubuntu/+source/network-manager
     source-type: git
-    source-branch: applied/ubuntu/noble-updates
+    source-branch: applied/ubuntu/resolute
     build-packages:
       - gettext
       - libglib2.0-dev
@@ -381,8 +381,8 @@ parts:
       ## We don't use dhclient so we don't need this helper
       - -usr/lib/NetworkManager/nm-dhcp-helper
       ## Things we don't support yet and don't have to ship
-      - -usr/lib/NetworkManager/1.46.0/libnm-device-plugin-adsl.so
-      - -usr/lib/NetworkManager/1.46.0/libnm-device-plugin-bluetooth.so
+      - -usr/lib/NetworkManager/1.54.2/libnm-device-plugin-adsl.so
+      - -usr/lib/NetworkManager/1.54.2/libnm-device-plugin-bluetooth.so
       ## Some additional build artifacts we do not need
       - -usr/lib/NetworkManager/*/*.la
       - -usr/lib/libnm.la


### PR DESCRIPTION
System snap tracks build upon Ubuntu classic LTS releases, so we have

* NetworkManager/snap-20 => builds upon core20/Focal
* NetworkManager/snap-22 => build upon core22/Jammy
* NetworkManager/snap-24 => builds upon core24/Noble
* NetworkManager/snap-26 => will be built upon core26/Resolute (once it exists, [Tags · canonical/core-base](https://github.com/canonical/core-base/tags))


For the upcoming core26 track, we need to prepare the `snapcraft.yaml` to build upon the `network-manager` source-package shipped in `resolute[-updates]`, setup a new snap-26 branch in the NM-snap repo at GitHub and new `26/{edge,beta,candidate,stable}` channels in the snapstore. Then we need to rebase the patches and fix any build failures in that branch and make sure the CI deployment to the “26/…” track works as expected (cf. https://github.com/canonical/system-snaps-cicd-tools/pull/33)