### PR TITLE
CI: monthly test-publish to edge

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - snap-24
+  schedule:
+    # Run on the first Sunday of the month at 02:00 UTC
+    - cron: '0 2 1-7 * SUN'
 
 jobs:
   publish_to_edge:


### PR DESCRIPTION
To avoid CI-pipeline failures going unnoticed for too long, we'll trigger a monthly build to `24/edge`, confirming the buildability.

Once this proves valuable, we might want do add the same functionality for the other tracks:
* `latest/edge`
* `snap-1.10/edge`
* `snap-20/edge`
* `snap-22/edge`
* (`snap-26/edge`)