### PR TITLE
Initial upgrade of network-manager for core26

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -3,7 +3,7 @@ name: Publish to edge
 on:
   push:
     branches:
-      - snap-24
+      - snap-26
   schedule:
     # Run on the first Sunday of the month at 02:00 UTC
     - cron: '0 2 1-7 * SUN'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release snap
 on:
   workflow_dispatch:
     branches:
-      - snap-24
+      - snap-26
 
 jobs:
   build_release:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Spread tests
 on:
   pull_request:
     branches:
-      - snap-24
+      - snap-26
 
 jobs:
   build:

--- a/docs/snap/installation.md
+++ b/docs/snap/installation.md
@@ -62,8 +62,10 @@ Now you have NetworkManager successfully installed.
 
 ## network-manager tracks and channels
 
-The network-manager snap has currently three tracks:
+The network-manager snap has currently multiple tracks:
 
+ * **26**: Contains upstream 1.54.2 and has a core26 base. The track
+   name refers to the base snap.
  * **24**: Contains upstream 1.46.0 and has a core24 base. The track
    name refers to the base snap.
  * **22**: Contains upstream 1.36.6 and has a core22 base. The track

--- a/snap-patch/dnsmasq.patch
+++ b/snap-patch/dnsmasq.patch
@@ -1,4 +1,4 @@
-From fdc76450eb0ded4e43fe1692041d4f912baa2345 Mon Sep 17 00:00:00 2001
+From 85b842faeb50b5c7d8e71c6a429422c0c35626bc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alfonso=20S=C3=A1nchez-Beato?=
  <alfonso.sanchez-beato@canonical.com>
 Date: Mon, 7 Mar 2022 08:55:17 +0100
@@ -10,10 +10,10 @@ Subject: [PATCH] snap: do not tinker with uid/gid, change fixed paths
  2 files changed, 18 insertions(+), 18 deletions(-)
 
 diff --git a/src/config.h b/src/config.h
-index 30e23d8..721e3f0 100644
+index 0994f95..c8d08a4 100644
 --- a/src/config.h
 +++ b/src/config.h
-@@ -204,7 +204,7 @@ RESOLVFILE
+@@ -214,7 +214,7 @@ RESOLVFILE
  #   elif defined(__ANDROID__)
  #      define LEASEFILE "/data/misc/dhcp/dnsmasq.leases"
  #   else
@@ -22,7 +22,7 @@ index 30e23d8..721e3f0 100644
  #   endif
  #endif
  
-@@ -212,7 +212,7 @@ RESOLVFILE
+@@ -222,7 +222,7 @@ RESOLVFILE
  #   if defined(__FreeBSD__)
  #      define CONFFILE "/usr/local/etc/dnsmasq.conf"
  #   else
@@ -31,7 +31,7 @@ index 30e23d8..721e3f0 100644
  #   endif
  #endif
  
-@@ -228,7 +228,7 @@ RESOLVFILE
+@@ -238,7 +238,7 @@ RESOLVFILE
  #   if defined(__ANDROID__)
  #      define RUNFILE "/data/dnsmasq.pid"
  #    else
@@ -41,10 +41,10 @@ index 30e23d8..721e3f0 100644
  #endif
  
 diff --git a/src/dnsmasq.c b/src/dnsmasq.c
-index 602daed..cfa09e9 100644
+index 9ac5217..3cf9aa3 100644
 --- a/src/dnsmasq.c
 +++ b/src/dnsmasq.c
-@@ -678,8 +678,8 @@ int main (int argc, char **argv)
+@@ -697,8 +697,8 @@ int main (int argc, char **argv)
  		 of the directory containing the file. That directory will
  		 need to by owned by the dnsmasq user, and the ownership of the
  		 file has to match, to keep systemd >273 happy. */
@@ -53,9 +53,9 @@ index 602daed..cfa09e9 100644
 +	      /* if (getuid() == 0 && ent_pw && ent_pw->pw_uid != 0 && fchown(fd, ent_pw->pw_uid, ent_pw->pw_gid) == -1) */
 +	      /*   chown_warn = errno; */
  
- 	      if (!read_write(fd, (unsigned char *)daemon->namebuff, strlen(daemon->namebuff), 0))
+ 	      if (!read_write(fd, (unsigned char *)daemon->namebuff, strlen(daemon->namebuff), RW_WRITE))
  		err = 1;
-@@ -724,16 +724,16 @@ int main (int argc, char **argv)
+@@ -747,16 +747,16 @@ int main (int argc, char **argv)
    if (!option_bool(OPT_DEBUG) && getuid() == 0)   
      {
        int bad_capabilities = 0;
@@ -80,7 +80,7 @@ index 602daed..cfa09e9 100644
    
        if (ent_pw && ent_pw->pw_uid != 0)
  	{     
-@@ -774,11 +774,11 @@ int main (int argc, char **argv)
+@@ -797,11 +797,11 @@ int main (int argc, char **argv)
  	    }
  	  
  	  /* finally drop root */
@@ -98,5 +98,5 @@ index 602daed..cfa09e9 100644
  #ifdef HAVE_LINUX_NETWORK
  	  data->effective &= ~(1 << CAP_SETUID);
 -- 
-2.25.1
+2.43.0
 

--- a/snap-patch/networkmanager/0001-dnsmasq-use-NMRUNDIR-instead-of-RUNSTATEDIR.patch
+++ b/snap-patch/networkmanager/0001-dnsmasq-use-NMRUNDIR-instead-of-RUNSTATEDIR.patch
@@ -1,8 +1,8 @@
-From d595bba8c25efbca1cffced2896d154ef93c6577 Mon Sep 17 00:00:00 2001
+From db8838c9ac377c7ed7a38731bedc4dd723866d90 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alfonso=20S=C3=A1nchez-Beato?=
  <alfonso.sanchez-beato@canonical.com>
 Date: Mon, 23 Mar 2020 09:10:15 +0100
-Subject: [PATCH 1/4] dnsmasq: use NMRUNDIR instead of RUNSTATEDIR
+Subject: [PATCH 1/3] dnsmasq: use NMRUNDIR instead of RUNSTATEDIR
 
 RUNSTATEDIR is not allowed under the current snapd apparmor rules
 ---
@@ -10,10 +10,10 @@ RUNSTATEDIR is not allowed under the current snapd apparmor rules
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/core/dnsmasq/nm-dnsmasq-manager.c b/src/core/dnsmasq/nm-dnsmasq-manager.c
-index 4ab91e7e3..ad3b76208 100644
+index 030a8e28e..966f67e79 100644
 --- a/src/core/dnsmasq/nm-dnsmasq-manager.c
 +++ b/src/core/dnsmasq/nm-dnsmasq-manager.c
-@@ -322,7 +322,7 @@ nm_dnsmasq_manager_new(const char *iface)
+@@ -358,7 +358,7 @@ nm_dnsmasq_manager_new(const char *iface)
  
      priv          = NM_DNSMASQ_MANAGER_GET_PRIVATE(manager);
      priv->iface   = g_strdup(iface);
@@ -23,5 +23,5 @@ index 4ab91e7e3..ad3b76208 100644
      return manager;
  }
 -- 
-2.25.1
+2.43.0
 

--- a/snap-patch/networkmanager/0002-Disable-tests-failing-on-launchpad.patch
+++ b/snap-patch/networkmanager/0002-Disable-tests-failing-on-launchpad.patch
@@ -1,58 +1,70 @@
-From 070448536e628032036c2d61eec5502c1e1aa770 Mon Sep 17 00:00:00 2001
+From bd0b16d7fadb89690fc7c39b7adf9ca1178e5745 Mon Sep 17 00:00:00 2001
 From: snapcraft <snapcraft@canonical.com>
 Date: Mon, 7 Mar 2022 15:24:03 +0100
-Subject: [PATCH 3/4] Disable tests failing on launchpad
+Subject: [PATCH 2/3] Disable tests failing on launchpad
 
 ---
- Makefile.am | 9 ---------
- 1 file changed, 9 deletions(-)
+ src/core/devices/tests/meson.build    | 1 -
+ src/core/platform/tests/meson.build   | 5 -----
+ src/core/settings/plugins/meson.build | 1 -
+ src/core/tests/meson.build            | 1 -
+ 4 files changed, 8 deletions(-)
 
-diff --git a/Makefile.am b/Makefile.am
-index 8aa8d3210..f00eb9616 100644
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -3166,8 +3166,6 @@ EXTRA_DIST += \
- # src/core/settings/plugins/keyfile/tests
- ###############################################################################
+diff --git a/src/core/devices/tests/meson.build b/src/core/devices/tests/meson.build
+index 871c32062..6ce7847c4 100644
+--- a/src/core/devices/tests/meson.build
++++ b/src/core/devices/tests/meson.build
+@@ -1,7 +1,6 @@
+ # SPDX-License-Identifier: LGPL-2.1-or-later
  
--check_programs += src/core/settings/plugins/keyfile/tests/test-keyfile-settings
--
- src_core_settings_plugins_keyfile_tests_test_keyfile_settings_CPPFLAGS = $(src_core_cppflags_test)
+ test_units = [
+-  'test-lldp',
+ ]
  
- src_core_settings_plugins_keyfile_tests_test_keyfile_settings_LDFLAGS = \
-@@ -4135,16 +4133,11 @@ check_programs_norun += \
+ foreach test_unit: test_units
+diff --git a/src/core/platform/tests/meson.build b/src/core/platform/tests/meson.build
+index 252c6840f..4dc31f522 100644
+--- a/src/core/platform/tests/meson.build
++++ b/src/core/platform/tests/meson.build
+@@ -5,16 +5,11 @@ test_linux_c_flags = test_c_flags + ['-DSETUP=nm_linux_platform_setup']
  
- check_programs += \
- 	src/core/platform/tests/test-address-fake \
--	src/core/platform/tests/test-address-linux \
- 	src/core/platform/tests/test-cleanup-fake \
--	src/core/platform/tests/test-cleanup-linux \
- 	src/core/platform/tests/test-link-fake \
--	src/core/platform/tests/test-link-linux \
- 	src/core/platform/tests/test-nmp-object \
- 	src/core/platform/tests/test-platform-general \
- 	src/core/platform/tests/test-route-fake \
--	src/core/platform/tests/test-route-linux \
--	src/core/platform/tests/test-tc-linux \
- 	$(NULL)
+ test_units = [
+   ['test-address-fake', 'test-address.c', test_fake_c_flags, default_test_timeout],
+-  ['test-address-linux', 'test-address.c', test_linux_c_flags, default_test_timeout],
+   ['test-cleanup-fake', 'test-cleanup.c', test_fake_c_flags, default_test_timeout],
+-  ['test-cleanup-linux', 'test-cleanup.c', test_linux_c_flags, default_test_timeout],
+   ['test-link-fake', 'test-link.c', test_fake_c_flags, default_test_timeout],
+-  ['test-link-linux', 'test-link.c', test_linux_c_flags, 900],
+   ['test-nmp-object', 'test-nmp-object.c', test_c_flags, default_test_timeout],
+   ['test-platform-general', 'test-platform-general.c', test_c_flags, default_test_timeout],
+   ['test-route-fake', 'test-route.c', test_fake_c_flags, default_test_timeout],
+-  ['test-route-linux', 'test-route.c', test_linux_c_flags, 900],
+-  ['test-tc-linux', 'test-tc.c', test_linux_c_flags, default_test_timeout],
+ ]
  
- src_core_platform_tests_monitor_CPPFLAGS = $(src_core_cppflags_test)
-@@ -4232,7 +4225,6 @@ src_core_devices_tests_ldflags = \
- 	$(SANITIZER_EXEC_LDFLAGS)
+ foreach test_unit: test_units
+diff --git a/src/core/settings/plugins/meson.build b/src/core/settings/plugins/meson.build
+index d4338a30a..ac6b453bf 100644
+--- a/src/core/settings/plugins/meson.build
++++ b/src/core/settings/plugins/meson.build
+@@ -9,5 +9,4 @@ if enable_ifupdown
+ endif
  
- check_programs += \
--	src/core/devices/tests/test-lldp \
- 	$(NULL)
- 
- src_core_devices_tests_test_lldp_CPPFLAGS = $(src_core_cppflags_test)
-@@ -4343,7 +4335,6 @@ check_programs += \
- 	src/core/tests/test-core \
- 	src/core/tests/test-core-with-expect \
- 	src/core/tests/test-dcb \
--	src/core/tests/test-l3cfg \
- 	src/core/tests/test-systemd \
- 	src/core/tests/test-utils \
- 	src/core/tests/test-wired-defname \
+ if enable_tests
+-  subdir('keyfile/tests')
+ endif
+diff --git a/src/core/tests/meson.build b/src/core/tests/meson.build
+index 78c689f79..2a0dac022 100644
+--- a/src/core/tests/meson.build
++++ b/src/core/tests/meson.build
+@@ -6,7 +6,6 @@ test_units = [
+   'test-core',
+   'test-core-with-expect',
+   'test-dcb',
+-  'test-l3cfg',
+   'test-utils',
+   'test-wired-defname',
+ ]
 -- 
-2.34.1
+2.43.0
 

--- a/snap-patch/networkmanager/0003-src-core-allow-reverse-ipv6-disabled-settings.patch
+++ b/snap-patch/networkmanager/0003-src-core-allow-reverse-ipv6-disabled-settings.patch
@@ -1,17 +1,17 @@
-From d5e87e52d8d25134daf51d9c84a28c06ffe497ee Mon Sep 17 00:00:00 2001
+From 6831794a5fecef7b9721f1b8e9f5d4af424c9154 Mon Sep 17 00:00:00 2001
 From: Philip Meulengracht <the_meulengracht@hotmail.com>
 Date: Thu, 27 Jun 2024 12:54:15 +0200
-Subject: [PATCH] src/core: allow reverse ipv6 disabled settings
+Subject: [PATCH 3/3] src/core: allow reverse ipv6 disabled settings
 
 ---
  src/core/NetworkManagerUtils.c | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
 diff --git a/src/core/NetworkManagerUtils.c b/src/core/NetworkManagerUtils.c
-index 08564903a..0d7fd2b2a 100644
+index 32df3d6df..6a7ab2cfa 100644
 --- a/src/core/NetworkManagerUtils.c
 +++ b/src/core/NetworkManagerUtils.c
-@@ -381,6 +381,16 @@ check_ip6_method(NMConnection *orig, NMConnection *candidate, GHashTable *settin
+@@ -379,6 +379,16 @@ check_ip6_method(NMConnection *orig, NMConnection *candidate, GHashTable *settin
           * simply take care of IPv6.
           */
          allow = TRUE;
@@ -20,7 +20,7 @@ index 08564903a..0d7fd2b2a 100644
 +                            NM_SETTING_IP6_CONFIG_METHOD_LINK_LOCAL,
 +                            NM_SETTING_IP6_CONFIG_METHOD_DISABLED,
 +                            NM_SETTING_IP6_CONFIG_METHOD_AUTO)) {
-+        /* If the generated connection method is 'ignore' and the candidate method 
++        /* If the generated connection method is 'ignore' and the candidate method
 +         * is 'link-local', disabled' or 'auto' we can take the connection, since
 +         * ipv6 probably has not been enabled.
 +         */
@@ -29,5 +29,5 @@ index 08564903a..0d7fd2b2a 100644
  
      if (allow) {
 -- 
-2.34.1
+2.43.0
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: network-manager
-version: 1.54.2-2-dev
+version: 1.54.3-0-dev
 summary: Network Manager
 description: |
   NetworkManager is a system network service that manages your network
@@ -392,8 +392,8 @@ parts:
       ## We don't use dhclient so we don't need this helper
       - -usr/lib/NetworkManager/nm-dhcp-helper
       ## Things we don't support yet and don't have to ship
-      - -usr/lib/NetworkManager/1.54.2/libnm-device-plugin-adsl.so
-      - -usr/lib/NetworkManager/1.54.2/libnm-device-plugin-bluetooth.so
+      - -usr/lib/NetworkManager/1.54.3/libnm-device-plugin-adsl.so
+      - -usr/lib/NetworkManager/1.54.3/libnm-device-plugin-bluetooth.so
       ## Some additional build artifacts we do not need
       - -usr/lib/NetworkManager/*/*.la
       - -usr/lib/libnm.la

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: network-manager
-version: 1.46.0-8-dev
+version: 1.54.2-2-dev
 summary: Network Manager
 description: |
   NetworkManager is a system network service that manages your network
@@ -11,7 +11,8 @@ description: |
     https://github.com/canonical/network-manager-snap/tree/snap-26
 base: core26
 confinement: strict
-grade: stable
+grade: devel
+build-base: devel
 
 # Since the uc20+ network-manager snap currently defaults to the native
 # netplan config plugin, the default format of connection files has
@@ -161,11 +162,12 @@ parts:
 
   networkmanager:
     after: [ stack-snaps-tools ]
-    plugin: autotools
+    plugin: meson
     source: https://git.launchpad.net/ubuntu/+source/network-manager
     source-type: git
     source-branch: applied/ubuntu/resolute
     build-packages:
+      - meson
       - gettext
       - libglib2.0-dev
       - ppp-dev
@@ -202,50 +204,50 @@ parts:
       - netplan.io
       - intltool
       - libnss3-dev
-    autotools-configure-parameters:
-      - --prefix=/usr
-      - --sysconfdir=/etc
-      - --localstatedir=/var
-      - --runstatedir=/run
-      - --disable-qt
+      - libnvme-dev
+    meson-parameters:
+      - -Dprefix=/usr
+      - -Dlibdir=lib
+      - -Dsysconfdir=/etc
+      - -Dlocalstatedir=/var
+      - -Druntime_dir=/run
+      - -Dqt=false
       # dhcp handled by systemd client
-      - --with-dhcpcd=no
-      - --with-dhclient=no
-      - --with-dnsmasq=/snap/$CRAFT_PROJECT_NAME/current/sbin/dnsmasq
-      - --with-iptables=/sbin/iptables
-      - --with-systemd-journal=yes
-      - --libexecdir=/snap/$CRAFT_PROJECT_NAME/current/usr/lib/NetworkManager
-      - --with-pppd=/snap/$CRAFT_PROJECT_NAME/current/usr/sbin/pppd
-      - --with-pppd-plugin-dir=/snap/$CRAFT_PROJECT_NAME/current/usr/lib/pppd/2.4.9/
-      - --with-dnssec-trigger=/usr/lib/dnssec-trigger/dnssec-trigger-script
-      - --with-systemdsystemunitdir=/usr/lib/systemd/system
-      - --with-udev-dir=/usr/lib/udev
-      - --with-crypto=gnutls
+      - -Ddhcpcd=false
+      - -Ddhclient=false
+      - -Ddnsmasq=/snap/$CRAFT_PROJECT_NAME/current/sbin/dnsmasq
+      - -Diptables=/sbin/iptables
+      - -Dsystemd_journal=true
+      - -Dlibexecdir=/snap/$CRAFT_PROJECT_NAME/current/usr/lib/NetworkManager
+      - -Dpppd=/snap/$CRAFT_PROJECT_NAME/current/usr/sbin/pppd
+      - -Dpppd_plugin_dir=/snap/$CRAFT_PROJECT_NAME/current/usr/lib/pppd/2.4.9/
+      - -Dsystemdsystemunitdir=/usr/lib/systemd/system
+      - -Dudev_dir=/usr/lib/udev
+      - -Dcrypto=gnutls
       # Explicitly disable session tracking, as it's not applicable on Ubuntu Core
-      - --with-session-tracking=no
-      - --with-suspend-resume=systemd
-      - --with-modem-manager-1
-      - --with-nmtui=yes
-      - --with-nmcli=yes
-      - --with-selinux=no
-      - --with-tests
-      - --with-libaudit=no
-      - --with-dhcpcanon=no
-      - --enable-netplan=yes
+      - -Dsession_tracking=no
+      - -Dsuspend_resume=systemd
+      - -Dmodem_manager=true
+      - -Dnmtui=true
+      - -Dnmcli=true
+      - -Dselinux=false
+      - -Dtests=yes
+      - -Dlibaudit=no
+      - -Dnetplan=true
       # Explicitly disable polkit, as it's not applicable on Ubuntu Core
-      - --enable-polkit=no
-      - --enable-ppp
-      - --enable-ifupdown
-      - --enable-introspection
-      - --enable-gtk-doc=no
-      - --enable-concheck
-      - --enable-teamdctl
-      - --enable-more-warnings=no
-      - --enable-modify-system=no
-      - --enable-ovs=no
-      - --with-nm-cloud-setup=no
+      - -Dpolkit=false
+      - -Dppp=true
+      - -Difupdown=true
+      - -Dintrospection=true
+      - -Ddocs=false
+      - -Dconcheck=true
+      - -Dteamdctl=true
+      - -Dwarning_level=1
+      - -Dmodify_system=false
+      - -Dovs=false
+      - -Dnm_cloud_setup=false
       # Set explicitly flags until lp: #1791946 is solved
-      - CFLAGS='-O2 -Wl,-z,relro,-z,now -pie -fpie'
+      - -Dc_args=['-O2','-Wl,-z,relro,-z,now','-pie','-fpie']
     # Generated netplan patch from https://github.com/slyon/NetworkManager/tree/slyon/backend-1.22.10
     # git format-patch 1.22.10 --full-index --binary --stdout > ../0002-nm-netplan-keyfile.patch -- !(.gitignore)
     override-build: |
@@ -256,13 +258,16 @@ parts:
       apt download network-manager-openvpn
       dpkg -x network-manager-openvpn_*.deb "$CRAFT_PART_INSTALL"/
 
+      # Apply patches in SRC directory, as the meson plugin won't copy sources
+      # in build dir after the pull step
+      cd "$CRAFT_PART_SRC"
       "$CRAFT_STAGE"/build-tools/check-versions network-manager yes
       git config user.email "snapcraft@canonical.com"
       git config user.name "snapcraft"
       git am "$CRAFT_PROJECT_DIR"/snap-patch/networkmanager/*.patch
+      cd "$CRAFT_PART_BUILD"
 
       # re-create configure
-      ./autogen.sh
       craftctl default
       # Strip binaries
       find "$CRAFT_PART_INSTALL"/ -executable -type f | xargs file -Ni |
@@ -274,11 +279,12 @@ parts:
       # that does not allow to pass a --root-dir argument, needed for testing
       _SNAP=$SNAP
       unset SNAP
-      make check
+      meson test -C "$CRAFT_PART_BUILD"
       SNAP=$_SNAP
       unset _SNAP
     stage-packages:
       - libcurl3t64-gnutls
+      - libdbus-1-dev
       - libjansson4
       - libpkcs11-helper1t64
       - libldap2
@@ -286,11 +292,14 @@ parts:
       - libnewt0.52
       - libnghttp2-14
       - libndp0
+      - libnvme-dev
       - libpsl5t64
       - librtmp1
       - libsasl2-2
       - libteamdctl0
       - libslang2
+      - libssh2-1t64
+      - mobile-broadband-provider-info
       - openvpn
       - ppp
 
@@ -348,6 +357,7 @@ parts:
       - usr/share/doc/libpsl5t64/changelog.*
       - usr/share/doc/librtmp1/changelog.*
       - usr/share/doc/libsasl2-2/changelog.*
+      - usr/share/doc/libssh2-1t64/changelog.*
       - usr/share/doc/libteamdctl0/changelog.*
       - usr/share/doc/libslang2/changelog.*
       - usr/share/doc/openvpn/changelog.*
@@ -357,6 +367,7 @@ parts:
       - usr/lib/*/libslang*
       - usr/lib/libnm*
       - usr/lib/*/libcurl-gnutls*
+      - usr/lib/*/libssh2*
       ## required for teamdctl
       - usr/lib/*/libjansson*
       # For openvpn

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -184,6 +184,7 @@ parts:
       - libpsl-dev
       - libcurl4-gnutls-dev
       - gtk-doc-tools
+      - libdbus-1-dev
       - libglib2.0-doc
       - libmm-glib-dev
       - libndp-dev
@@ -284,7 +285,7 @@ parts:
       unset _SNAP
     stage-packages:
       - libcurl3t64-gnutls
-      - libdbus-1-dev
+      - libdbus-1-3
       - libjansson4
       - libpkcs11-helper1t64
       - libldap2
@@ -292,7 +293,6 @@ parts:
       - libnewt0.52
       - libnghttp2-14
       - libndp0
-      - libnvme-dev
       - libpsl5t64
       - librtmp1
       - libsasl2-2
@@ -324,6 +324,7 @@ parts:
       # configuration
       - etc/NetworkManager/*
       # docs
+      - usr/share/doc/libdbus-1-3/copyright
       - usr/share/doc/libcurl3t64-gnutls/copyright
       - usr/share/doc/libibverbs1/copyright
       - usr/share/doc/libjansson4/copyright
@@ -340,9 +341,12 @@ parts:
       - usr/share/doc/libsasl2-2/copyright
       - usr/share/doc/libteamdctl0/copyright
       - usr/share/doc/libslang2/copyright
+      - usr/share/doc/libssh2-1t64/copyright
+      - usr/share/doc/mobile-broadband-provider-info/copyright
       - usr/share/doc/openvpn/copyright
       - usr/share/doc/ppp/copyright
       - usr/share/doc/network-manager-openvpn/copyright
+      - usr/share/doc/libdbus-1-3/changelog.*
       - usr/share/doc/libcurl3t64-gnutls/changelog.*
       - usr/share/doc/libibverbs1/changelog.*
       - usr/share/doc/libjansson4/changelog.*
@@ -360,13 +364,17 @@ parts:
       - usr/share/doc/libssh2-1t64/changelog.*
       - usr/share/doc/libteamdctl0/changelog.*
       - usr/share/doc/libslang2/changelog.*
+      - usr/share/doc/mobile-broadband-provider-info/changelog.*
       - usr/share/doc/openvpn/changelog.*
       - usr/share/doc/ppp/changelog.*
       - usr/share/doc/network-manager-openvpn/changelog.*
+      # mobile provider database
+      - usr/share/mobile-broadband-provider-info/*
       # libraries
       - usr/lib/*/libslang*
       - usr/lib/libnm*
       - usr/lib/*/libcurl-gnutls*
+      - usr/lib/*/libdbus*
       - usr/lib/*/libssh2*
       ## required for teamdctl
       - usr/lib/*/libjansson*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,8 +8,8 @@ description: |
   PPPoE devices, provides VPN integration with a variety of different
   VPN services.
   Please find the source code for this track at:
-    https://code.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/+git/network-manager/+ref/snap-24
-base: core24
+    https://github.com/canonical/network-manager-snap/tree/snap-26
+base: core26
 confinement: strict
 grade: stable
 
@@ -143,7 +143,7 @@ parts:
     plugin: make
     source: https://git.launchpad.net/ubuntu/+source/dnsmasq
     source-type: git
-    source-branch: applied/ubuntu/noble-updates
+    source-branch: applied/ubuntu/resolute
     build-packages:
       - build-essential
     make-parameters:
@@ -164,7 +164,7 @@ parts:
     plugin: autotools
     source: https://git.launchpad.net/ubuntu/+source/network-manager
     source-type: git
-    source-branch: applied/ubuntu/noble-updates
+    source-branch: applied/ubuntu/resolute
     build-packages:
       - gettext
       - libglib2.0-dev
@@ -381,8 +381,8 @@ parts:
       ## We don't use dhclient so we don't need this helper
       - -usr/lib/NetworkManager/nm-dhcp-helper
       ## Things we don't support yet and don't have to ship
-      - -usr/lib/NetworkManager/1.46.0/libnm-device-plugin-adsl.so
-      - -usr/lib/NetworkManager/1.46.0/libnm-device-plugin-bluetooth.so
+      - -usr/lib/NetworkManager/1.54.2/libnm-device-plugin-adsl.so
+      - -usr/lib/NetworkManager/1.54.2/libnm-device-plugin-bluetooth.so
       ## Some additional build artifacts we do not need
       - -usr/lib/NetworkManager/*/*.la
       - -usr/lib/libnm.la

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -220,7 +220,7 @@ parts:
       - -Dsystemd_journal=true
       - -Dlibexecdir=/snap/$CRAFT_PROJECT_NAME/current/usr/lib/NetworkManager
       - -Dpppd=/snap/$CRAFT_PROJECT_NAME/current/usr/sbin/pppd
-      - -Dpppd_plugin_dir=/snap/$CRAFT_PROJECT_NAME/current/usr/lib/pppd/2.4.9/
+      - -Dpppd_plugin_dir=/snap/$CRAFT_PROJECT_NAME/current/usr/lib/pppd/2.5.2/
       - -Dsystemdsystemunitdir=/usr/lib/systemd/system
       - -Dudev_dir=/usr/lib/udev
       - -Dcrypto=gnutls
@@ -304,7 +304,7 @@ parts:
       - ppp
 
     organize:
-      snap/$CRAFT_PROJECT_NAME/current/usr/lib/pppd/2.4.9/nm-pppd-plugin.so: usr/lib/pppd/2.4.9/nm-pppd-plugin.so
+      snap/$CRAFT_PROJECT_NAME/current/usr/lib/pppd/2.5.2/nm-pppd-plugin.so: usr/lib/pppd/2.5.2/nm-pppd-plugin.so
       snap/$CRAFT_PROJECT_NAME/current/usr/lib/NetworkManager: usr/lib/NetworkManager
       usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/NetworkManager: usr/lib/NetworkManager
 
@@ -317,7 +317,7 @@ parts:
       - usr/bin/nmtui-hostname
       - usr/sbin/pppd
       - usr/lib/*/NetworkManager
-      - usr/lib/pppd/2.4.9/nm-pppd-plugin.so
+      - usr/lib/pppd/2.5.2/nm-pppd-plugin.so
       - usr/lib/NetworkManager
       - usr/sbin/NetworkManager
       - usr/sbin/openvpn

--- a/spread.yaml
+++ b/spread.yaml
@@ -38,25 +38,38 @@ environment:
   DEFAULT_NETPLAN_FILE: 50-cloud-init.yaml
 
 backends:
-  google:
-    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    location: snapd-spread/us-east1-b
-    plan: n2-standard-2
+  openstack-dev:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_STG_AMD64_PS7")'
+    plan: shared.xsmall
     halt-timeout: 2h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.54.0/24:4000]
+    volume-auto-delete: true
+    environment:
+      SNAPD_USE_PROXY: 'true'
+      HTTP_PROXY: 'http://egress.ps7.internal:3128'
+      HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+      http_proxy: 'http://egress.ps7.internal:3128'
+      https_proxy: 'http://egress.ps7.internal:3128'
+      no_proxy: '127.0.0.1,127.0.0.53,localhost'
+      NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
+      NTP_SERVER: 'ntp.ps7.internal'
     systems:
-      - ubuntu-core-24-64:
-          image: ubuntu-24.04-64
+      - ubuntu-core-26-64:
+          image: ubuntu-26.04-64
           workers: 8
           storage: 20G
     prepare: |
-      # Builds UC image on top of classic 24.04
+      # Builds UC image on top of classic 26.04
       "$TESTSLIB"/prepare-restore.sh --prepare-suite
   qemu:
     memory: 4G
     systems:
-      - ubuntu-core-24:
-          # TODO how is this done in snapd spread?
-          #bios: /usr/share/OVMF/OVMF_CODE.fd
+      - ubuntu-core-26:
+          bios: uefi
           username: test
           password: test
 
@@ -90,7 +103,10 @@ prepare: |
   "$SYSTEMSNAPSTESTLIB"/prepare.sh
 
 prepare-each: |
-  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 24/edge
+  # OBS: This is temporary to bootstrap
+  snap install --dangerous "$PROJECT_PATH"/"$name"*_amd64.snap
+  # Run prepare-each step which is a bit of a no-op now
+  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/stable
 
 restore-each: |
   "$SYSTEMSNAPSTESTLIB"/restore-each.sh

--- a/spread.yaml
+++ b/spread.yaml
@@ -105,9 +105,6 @@ prepare: |
   "$SYSTEMSNAPSTESTLIB"/prepare.sh
 
 prepare-each: |
-  # OBS: This is temporary to bootstrap
-  # Will be removed when the snap is published on the store in the stable channel
-  snap install --dangerous "$PROJECT_PATH"/"$SNAP_NAME"*_amd64.snap
   # Run prepare-each step which is a bit of a no-op now
   "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/stable
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -67,6 +67,8 @@ backends:
       "$TESTSLIB"/prepare-restore.sh --prepare-suite
   qemu:
     memory: 4G
+    environment:
+      DEFAULT_NETPLAN_FILE: 00-snapd-config.yaml
     systems:
       - ubuntu-core-26:
           bios: uefi
@@ -104,7 +106,8 @@ prepare: |
 
 prepare-each: |
   # OBS: This is temporary to bootstrap
-  snap install --dangerous "$PROJECT_PATH"/"$name"*_amd64.snap
+  # Will be removed when the snap is published on the store in the stable channel
+  snap install --dangerous "$PROJECT_PATH"/"$SNAP_NAME"*_amd64.snap
   # Run prepare-each step which is a bit of a no-op now
   "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/stable
 

--- a/tests/core/no-netplan-default-config/task.yaml
+++ b/tests/core/no-netplan-default-config/task.yaml
@@ -36,7 +36,7 @@ execute: |
 
     # We should only have a single active configuration
     test $(network-manager.nmcli -m multiline -f UUID c show --active | wc -l) -eq 1
-    network-manager.nmcli -m multiline -f DEVICE c show --active | MATCH "ens4"
+    network-manager.nmcli -m multiline -f DEVICE c show --active | MATCH $eth_if
 
     # Verify that we can modify the automatically created connection
     connection=$(network-manager.nmcli -m multiline -f UUID c show --active | awk '{print$2;exit}')


### PR DESCRIPTION
Update of patches and snapcraft recipe to cope with the evolution of the Network Manager code.

Some evolutions in the snapd interfaces are as well needed.