### PR TITLE
CI: enable workflow dispatch for edge builds

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -1,6 +1,9 @@
 name: Publish to edge
 
 on:
+  workflow_dispatch:
+    branches:
+      - snap-24
   push:
     branches:
       - snap-24


### PR DESCRIPTION
Makes it possible to manually release to edge, analogous to what is already present in the beta channel workflow.