### PR TITLE
Add layout for /usr/share/mobile-broadband-provider-info/serviceproviders.xml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,6 +71,8 @@ layout:
   # LD_LIBRARY_PATH is not passed down by openvpn).
   /usr/lib/libnm.so.0:
     symlink: $SNAP/usr/lib/libnm.so.0
+  /usr/share/mobile-broadband-provider-info/serviceproviders.xml:
+    symlink: $SNAP/usr/share/mobile-broadband-provider-info/serviceproviders.xml
 
 apps:
   nmcli:


### PR DESCRIPTION
In the current snap, setting up a network connection for an LTE modem with the key `auto-config: true` set, bringing up the connection will fail with:
```
# nmcli con up modem
Error: Connection activation failed: Failed to select the specified APN
Hint: use 'journalctl -xe NM_CONNECTION=4d0d179e-b5d1-3496-9557-1f9e2c51a03f + NM_DEVICE=ttyACM1' to get more details.
```
The journal shows:
```
Apr 10 11:53:16 localhost.localdomain NetworkManager[9767]: <warn>  [1775821996.0619] modem-broadband[ttyACM1]: failed to connect 'modem': APN not found: Error opening service provider database: Error opening file /usr/share/mobile-broadband-provider-info/serviceproviders.xml: No such file or directory
```

Since the file exists on the system at `/snap/network-manager/1033/usr/share/mobile-broadband-provider-info/serviceproviders.xml`, what is missing from the snap is the layout:
```
  /usr/share/mobile-broadband-provider-info/serviceproviders.xml:
    symlink: $SNAP/usr/share/mobile-broadband-provider-info/serviceproviders.xml
```

This has been tested on a running UC26 system by using `snap try`, and by installing the re-packed snap in dangerous mode.