### PR TITLE
snapcraft.yaml: switch to resolute-proposed.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -145,7 +145,7 @@ parts:
     plugin: make
     source: https://git.launchpad.net/ubuntu/+source/dnsmasq
     source-type: git
-    source-branch: applied/ubuntu/resolute
+    source-branch: applied/ubuntu/resolute-proposed
     build-packages:
       - build-essential
     make-parameters:
@@ -166,7 +166,7 @@ parts:
     plugin: meson
     source: https://git.launchpad.net/ubuntu/+source/network-manager
     source-type: git
-    source-branch: applied/ubuntu/resolute
+    source-branch: applied/ubuntu/resolute-proposed
     build-packages:
       - meson
       - gettext


### PR DESCRIPTION
This is to avoid version mismatch issues until resolute-updates branch is available